### PR TITLE
Feature/add iphone xr mono example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Unignore all dirs
 !*/
 
+.vscode
 CMakeLists.txt.user
 CMakeLists_modified.txt
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,10 @@ endif()
 #Monocular examples
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/Examples/Monocular)
 
+add_executable(mono_iphonexr
+        Examples/Monocular/mono_iphonexr.cc)
+target_link_libraries(mono_iphonexr ${PROJECT_NAME})
+
 add_executable(mono_tum
         Examples/Monocular/mono_tum.cc)
 target_link_libraries(mono_tum ${PROJECT_NAME})

--- a/Examples/Monocular/IphoneXR.yaml
+++ b/Examples/Monocular/IphoneXR.yaml
@@ -1,0 +1,78 @@
+%YAML:1.0
+
+#--------------------------------------------------------------------------------------------
+# System config
+#--------------------------------------------------------------------------------------------
+
+# When the variables are commented, the system doesn't load a previous session or not store the current one
+
+# If the LoadFile doesn't exist, the system give a message and create a new Atlas from scratch
+#System.LoadAtlasFromFile: "Session_MH01_MH02_MH03_Mono"
+
+# The store file is created from the current session, if a file with the same name exists it is deleted
+#System.SaveAtlasToFile: "Session_MH01_MH02_MH03_Mono"
+
+#--------------------------------------------------------------------------------------------
+# Camera Parameters. Adjust them!
+#--------------------------------------------------------------------------------------------
+File.version: "1.0"
+
+Camera.type: "PinHole"
+
+# Camera calibration and distortion parameters (OpenCV) 
+Camera1.fx: 1123.554
+Camera1.fy: 1121.795
+Camera1.cx: 353.071
+Camera1.cy: 644.460
+
+Camera1.k1: 0.24413357
+Camera1.k2: -1.24211413
+Camera1.p1: 0.00211013
+Camera1.p2: -0.00135227
+
+Camera.width: 720
+Camera.height: 1280
+
+Camera.newWidth: 720
+Camera.newHeight: 1280
+
+# Camera frames per second 
+Camera.fps: 20
+
+# Color order of the images (0: BGR, 1: RGB. It is ignored if images are grayscale)
+Camera.RGB: 1
+
+#--------------------------------------------------------------------------------------------
+# ORB Parameters
+#--------------------------------------------------------------------------------------------
+
+# ORB Extractor: Number of features per image
+ORBextractor.nFeatures: 1000
+
+# ORB Extractor: Scale factor between levels in the scale pyramid 	
+ORBextractor.scaleFactor: 1.2
+
+# ORB Extractor: Number of levels in the scale pyramid	
+ORBextractor.nLevels: 8
+
+# ORB Extractor: Fast threshold
+# Image is divided in a grid. At each cell FAST are extracted imposing a minimum response.
+# Firstly we impose iniThFAST. If no corners are detected we impose a lower value minThFAST
+# You can lower these values if your images have low contrast			
+ORBextractor.iniThFAST: 20
+ORBextractor.minThFAST: 7
+
+#--------------------------------------------------------------------------------------------
+# Viewer Parameters
+#---------------------------------------------------------------------------------------------
+Viewer.KeyFrameSize: 0.05
+Viewer.KeyFrameLineWidth: 1.0
+Viewer.GraphLineWidth: 0.9
+Viewer.PointSize: 2.0
+Viewer.CameraSize: 0.08
+Viewer.CameraLineWidth: 3.0
+Viewer.ViewpointX: 0.0
+Viewer.ViewpointY: -0.7
+Viewer.ViewpointZ: -1.8
+Viewer.ViewpointF: 500.0
+

--- a/Examples/Monocular/IphoneXR.yaml
+++ b/Examples/Monocular/IphoneXR.yaml
@@ -37,7 +37,7 @@ Camera.newWidth: 720
 Camera.newHeight: 1280
 
 # Camera frames per second 
-Camera.fps: 20
+Camera.fps: 30
 
 # Color order of the images (0: BGR, 1: RGB. It is ignored if images are grayscale)
 Camera.RGB: 1

--- a/Examples/Monocular/mono_iphonexr.cc
+++ b/Examples/Monocular/mono_iphonexr.cc
@@ -1,0 +1,91 @@
+#include<iostream>
+#include<algorithm>
+#include<fstream>
+#include<chrono>
+
+#include<opencv2/core/core.hpp>
+
+#include<System.h>
+
+int main(int argc, char **argv)
+{  
+    // Video file to do slam on.
+    if (argc != 2) {
+        std::cout << "Usage from main folder:\n$ ./Examples/Monocular/mono_iphonexr <path to your video file>\nUnexpected number of arguments found. Exiting...\n";
+        return 1;
+    }
+    std::string file_path(argv[1]);
+    std::cout << "Working on " << file_path << "\n";
+    cv::VideoCapture cap(file_path);
+
+    cout << endl << "-------" << endl;
+    cout.precision(17);
+
+
+    int fps = 20;
+    float dT = 1.f/fps;
+
+    std::string orb_vocabulary_path = "./Vocabulary/ORBvoc.txt";
+    std::string settings_path = "./Examples/Monocular/IphoneXR.yaml";
+
+    bool enablePanglinVisualization = false;
+    // Create SLAM system. It initializes all system threads and gets ready to process frames.
+    ORB_SLAM3::System SLAM(orb_vocabulary_path, settings_path, ORB_SLAM3::System::MONOCULAR, enablePanglinVisualization);
+    float imageScale = SLAM.GetImageScale();
+
+    std::cout << "Image scale: " << imageScale << std::endl;
+
+    double t_resize = 0.f;
+    double t_track = 0.f;
+
+    // Main loop
+    cv::Mat image;
+    int proccIm = 0;
+    int frame_count = 0;
+    while(1)
+    {
+
+        // Read image from file
+        cap >> image; 
+        double tframe = frame_count * dT;
+
+        if(image.empty())
+        {
+            cerr << endl << "Failed to load image at, end of video?\n";
+            break; // Break out of loop to go to shutdown procedures.
+        }
+
+        if(imageScale != 1.f)
+        {
+
+            int width = image.cols * imageScale;
+            int height = image.rows * imageScale;
+            cv::resize(image, image, cv::Size(width, height));
+        }
+
+        // Pass the image to the SLAM system
+        // cout << "tframe = " << tframe << endl;
+        SLAM.TrackMonocular(image, tframe);
+
+        // Wait to load the next frame
+        
+    }
+    // Stop all threads
+    SLAM.Shutdown();
+
+    // Save camera trajectory
+    if (1)
+    {
+        const string kf_file =  "kf_" + file_path + ".txt";
+        const string f_file =  "f_" + file_path + ".txt";
+        SLAM.SaveTrajectoryEuRoC(f_file);
+        SLAM.SaveKeyFrameTrajectoryEuRoC(kf_file);
+    }
+    else
+    {
+        SLAM.SaveTrajectoryEuRoC("CameraTrajectory.txt");
+        SLAM.SaveKeyFrameTrajectoryEuRoC("KeyFrameTrajectory.txt");
+    }
+
+    return 0;
+}

--- a/Examples/Monocular/mono_iphonexr.cc
+++ b/Examples/Monocular/mono_iphonexr.cc
@@ -15,7 +15,7 @@ std::string base_name(std::string const & path)
 
 std::string remove_extension(std::string const & filename)
 {
-    size_t p = filename.find_last_not_of('.');
+    std::size_t p = filename.rfind('.');
     return p > 0 && p != std::string::npos ? filename.substr(0, p) : filename;
 }
 
@@ -46,9 +46,6 @@ int main(int argc, char **argv)
     float imageScale = SLAM.GetImageScale();
 
     std::cout << "Image scale: " << imageScale << std::endl;
-
-    double t_resize = 0.f;
-    double t_track = 0.f;
 
     // Main loop
     cv::Mat image;

--- a/Examples/Monocular/mono_iphonexr.cc
+++ b/Examples/Monocular/mono_iphonexr.cc
@@ -1,11 +1,23 @@
-#include<iostream>
-#include<algorithm>
-#include<fstream>
-#include<chrono>
+#include <iostream>
+#include <algorithm>
+#include <fstream>
+#include <chrono>
 
-#include<opencv2/core/core.hpp>
+#include <opencv2/core/core.hpp>
 
-#include<System.h>
+#include <System.h>
+
+
+std::string base_name(std::string const & path)
+{
+    return path.substr(path.find_last_of("/") + 1);
+}
+
+std::string remove_extension(std::string const & filename)
+{
+    size_t p = filename.find_last_not_of('.');
+    return p > 0 && p != std::string::npos ? filename.substr(0, p) : filename;
+}
 
 int main(int argc, char **argv)
 {  
@@ -76,8 +88,9 @@ int main(int argc, char **argv)
     // Save camera trajectory
     if (1)
     {
-        const string kf_file =  "kf_" + file_path + ".txt";
-        const string f_file =  "f_" + file_path + ".txt";
+        const string filename = remove_extension(base_name(file_path));
+        const string kf_file =  "kf_" + filename + ".txt";
+        const string f_file =  "f_" + filename + ".txt";
         SLAM.SaveTrajectoryEuRoC(f_file);
         SLAM.SaveKeyFrameTrajectoryEuRoC(kf_file);
     }

--- a/Examples/Monocular/mono_iphonexr.cc
+++ b/Examples/Monocular/mono_iphonexr.cc
@@ -33,14 +33,15 @@ int main(int argc, char **argv)
     cout << endl << "-------" << endl;
     cout.precision(17);
 
-
-    int fps = 20;
-    float dT = 1.f/fps;
-
     std::string orb_vocabulary_path = "./Vocabulary/ORBvoc.txt";
     std::string settings_path = "./Examples/Monocular/IphoneXR.yaml";
 
+    cv::FileStorage fSettings(settings_path, cv::FileStorage::READ);
+    int fps = fSettings["Camera.fps"];
+    float dT = 1.f/fps;
+
     bool enablePanglinVisualization = false;
+
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
     ORB_SLAM3::System SLAM(orb_vocabulary_path, settings_path, ORB_SLAM3::System::MONOCULAR, enablePanglinVisualization);
     float imageScale = SLAM.GetImageScale();

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 echo "Configuring and building Thirdparty/DBoW2 ..."
 
 cd Thirdparty/DBoW2
-mkdir build
+mkdir build -p
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 make -j
@@ -10,7 +10,7 @@ cd ../../g2o
 
 echo "Configuring and building Thirdparty/g2o ..."
 
-mkdir build
+mkdir build -p
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 make -j
@@ -19,7 +19,7 @@ cd ../../Sophus
 
 echo "Configuring and building Thirdparty/Sophus ..."
 
-mkdir build
+mkdir build -p
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 make -j
@@ -34,7 +34,7 @@ cd ..
 
 echo "Configuring and building ORB_SLAM3 ..."
 
-mkdir build
+mkdir build -p
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 make -j4


### PR DESCRIPTION
Add example program and calibration for running on videos captured by Iphone XR. 

Usage from project root:
./Examples/Monocular/mono_iphonexr /path/to/my/video.mp4 

Generates:
f_<argument provided filename>.txt
kf_<argument provided filename>.txt